### PR TITLE
Fix readme

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@
 
 This is [libarchive](https://www.libarchive.org/), packaged for [Zig](https://ziglang.org/).
 
-libarchive version: 3.7.3
+libarchive version: 3.7.9
 Supported Zig version: 14.0


### PR DESCRIPTION
The libarchive version in the README was missed in the last version bump. This also shortens "Continuous Integration" to "CI" for the GH badge on the README.